### PR TITLE
Update Messages.js - bugfix #202 SamsungHJ API

### DIFF
--- a/lib/H-and-J-Series-lib/Connection/Messages.js
+++ b/lib/H-and-J-Series-lib/Connection/Messages.js
@@ -16,7 +16,7 @@ class Messages {
   }
 
   handle(message) {
-    const handle = this.messageTypes.find(messageHandler => messageHandler.matcher(message.data))
+    const handle = this.messageTypes.find(messageHandler => messageHandler.matcher(message.data.toString()))
     if (!handle) {
       console.debug('unknown message received: ' + message.data)
       return new Promise(resolve => resolve())

--- a/main.js
+++ b/main.js
@@ -356,7 +356,7 @@ async function main() {
 
                             createObjectsAndStates();
 
-                            remote = { powerKey: 'KEY_POWER', send: (cmd, cn) => {
+                            remote = { powerKey: 'KEY_POWER', send: (cmd, cb) => {
                                 remoteHJ.sendKey(cmd);
                                 cb && cb();
                             } };


### PR DESCRIPTION
After update of js-controller to v.6.0.9 message.data is returned as objekt type. Matcher() method requires it stringified (via .tostring()). The same was already provided in SamsungTvConnection.js v.0.6.0 before (calling messages.on()).